### PR TITLE
Strip spaces from text before copying to the clipboard.

### DIFF
--- a/addon/globalPlugins/reviewCursorCopier/__init__.py
+++ b/addon/globalPlugins/reviewCursorCopier/__init__.py
@@ -18,7 +18,8 @@ def copyReviewUnitToClipboard(unit, copyFrom=None):
         info.expand(unit)
         if copyFrom:
             info.setEndPoint(pos, copyFrom)
-        copyStatus = info.copyToClipboard()
+        text = info.clipboardText.strip()
+        copyStatus = api.copyToClip(text)
         if not copyStatus:
             raise RuntimeError
         # Translators: Copying to the clipboard was successful.


### PR DESCRIPTION
This is particularly useful in command consoles using UIA, since lines contain many trailing spaces in that case