### PR TITLE
Add command to copy the first URL on the line under the review cursor.

### DIFF
--- a/addon/globalPlugins/reviewCursorCopier/__init__.py
+++ b/addon/globalPlugins/reviewCursorCopier/__init__.py
@@ -2,12 +2,16 @@
 # (C) 2017 Tuukka Ojala <tuukka.ojala@gmail.com>
 # Distributed under GNU GPL V2
 
+import re
+
 import addonHandler
 import api
 import globalCommands
 import globalPluginHandler
 import textInfos
 import ui
+
+RE_URL = re.compile(r"[a-zA-Z]+://[^ ]*")
 
 addonHandler.initTranslation()
 
@@ -60,3 +64,24 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         copyReviewUnitToClipboard(textInfos.UNIT_WORD, copyFrom="startToStart")
     # Translators: Describes the "copy remaining word to clipboard" command.
     script_copyRemainingWordToClipboard.__doc__ = _("Copies the text until the end of the current word to the clipboard.")
+
+    def script_copyUrlToClipboard(self, gesture):
+        try:
+            info = api.getReviewPosition()
+            info.expand(textInfos.UNIT_LINE)
+            m = RE_URL.search(info.text)
+            if not m:
+                # Translators: There was no URL on the line under the review
+                # cursor.
+                ui.message(_("No URL on this line"))
+                return
+            copyStatus = api.copyToClip(m.group(0))
+            if not copyStatus:
+                raise RuntimeError
+            # Translators: Copying to the clipboard was successful.
+            ui.message(_("Copied"))
+        except:
+            # Translators: Copying to the clipboard failed.
+            ui.message(_("Failed to copy"))
+    # Translators: Describes the "copy URL to clipboard" command.
+    script_copyUrlToClipboard.__doc__ = _("Copies the first URL on the line under the review cursor to the clipboard.")

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ This NVDA add-on provides various commands for copying the text under the review
 * Copy from the review cursor to the end of the current line
 * Copy from the start of the current word to the review cursor
 * Copy from the review cursor to the end of the current word
+* Copy the first URL on the line under the review cursor
 
 None of these commands have key bindings by default. Please use the input gestures dialog located under the NVDA settings menu to set them. All of the commands provided by this add-on can be found under the "text review" category. More information about setting and modifying input gestures can be found in the NVDA user guide.
 


### PR DESCRIPTION
This might be out of scope for this add-on, in which case please feel free to close this. The use case is that I spend a lot of time in terminals and some commands show a URL that I need to open in a web browser. I could get to the URL by moving by word, but that's pretty tedious, especially if the command is waiting for action and displays a progress indicator every few seconds, causing the cursor to move UNDERNEATH YOU. This command makes the process much faster.
The regular expression I'm using is very simplistic, but I think it should be good enough for most cases.